### PR TITLE
Update Taskbar World.inc

### DIFF
--- a/Skins/Enigma/Taskbar/World/World.inc
+++ b/Skins/Enigma/Taskbar/World/World.inc
@@ -1,13 +1,24 @@
 ;---------------------------------------------------------------------
 ; MEASURES
 
+[MeasureUTC]
+Measure=Time
+TimeZone=0
+
+[MeasureUNIX]
+Measure=Calc
+Formula=MeasureUTC-11644473600
+
 [MeasureTimeZone]
 Measure=Plugin
 Plugin=WebParser
 UpdateRate=3600
-Url=http://ws.geonames.org/timezone?lat=#CurrentCodeLat#&lng=#CurrentCodeLon#
-RegExp=<dstOffset>(.*)</dstOffset>
+Url=https://maps.googleapis.com/maps/api/timezone/xml?location=#CurrentCodeLat#,#CurrentCodeLon#&timestamp=[&MeasureUNIX]&sensor=false
+RegExp=(?siU)<raw_offset>(.*)</dst_offset>
 StringIndex=1
+DynamicVariables=1
+RegExpSubstitute=1
+Substitute="(.*)</raw_offset>[^<]*<dst_offset>(.*)":"((\1+\2)/3600)"
 
 [MeasureTime]
 Measure=Time


### PR DESCRIPTION
Applying the same fix to the taskbar world.inc file that was applied to the sidebar world.inc file. Causes World1, World2 and World3 taskbar clocks show appropriate time instead of all showing GMT.
