### PR TITLE
Allow special characters in Gmail passwords

### DIFF
--- a/Skins/Enigma/Options/Options.lua
+++ b/Skins/Enigma/Options/Options.lua
@@ -64,6 +64,20 @@ end
 -----------------------------------------------------------------------
 -- OPTION-SPECIFIC PARSING FUNCTIONS
 
+function urlEncode( str )
+   if ( str ) then
+      str = string.gsub( str, "\n", "\r\n" )
+      str = string.gsub( str, "([^%w ])",
+         function (c) return string.format( "%%%02X", string.byte(c) ) end )
+      str = string.gsub( str, " ", "+" )
+   end
+   return str
+end
+
+function ParsePassword(_, Value)
+	return urlEncode(Value)
+end
+
 function ParseProtocol(_, Value)
 	return Value:match('://') and Value or 'http://' .. Value
 end
@@ -169,7 +183,10 @@ Options = {
 		Parse   = ParseGmail,
 		Dependents = {'GmailPassword', 'GmailUrl', 'GmailDomain'}
 	},
-	GmailPassword = {Configs = { 'Sidebar\\Reader\\Gmail', 'Taskbar\\Reader\\Gmail' },},
+	GmailPassword = {
+		Configs = { 'Sidebar\\Reader\\Gmail', 'Taskbar\\Reader\\Gmail' },
+		Parse   = ParsePassword
+	},
 	GmailUrl = {},
 	GmailDomain = {},
 	FacebookFeed = {


### PR DESCRIPTION
This commit adds URL encoding to Gmail passwords so that special characters will not break the Gmail feed URL. In the future, the same encoding could be applied to the GmailUsername to allow for special characters, if necessary.

After applying this change, follow these steps:
- Open the Enigma options interface
- Save your Gmail password again
- Refresh the Gmail skin
- Your Gmail messages should appear again